### PR TITLE
HCK-10529: improve length conversion for all char convertible types

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -115,17 +115,17 @@
 					"hasMaxLength": true
 				},
 				"to": {
-					"length": 21844
+					"length": 255
 				}
 			},
 			{
 				"from": {
 					"type": "varchar",
-					"mode": "char",
+					"mode": "character",
 					"hasMaxLength": true
 				},
 				"to": {
-					"length": 255
+					"length": 21844
 				}
 			},
 			{
@@ -134,7 +134,7 @@
 					"hasMaxLength": true
 				},
 				"to": {
-					"length": 21844
+					"length": 255
 				}
 			},
 			{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10529" title="HCK-10529" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10529</a>  [MariaDB/MySQL] char datatype with max length incorrect derived/converted from/to Poly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Improved length conversion for all char convertible types